### PR TITLE
Switch from urllib2 to requests

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -100,7 +100,8 @@ class AdsAPI(object):
     # New API
     def make_labeled_batch_request(self, batch):
         """Makes a batched request with label against the Facebook Ads API endpoint."""
-        labels, queries = batch.items()
+        labels = batch.keys()
+        queries = batch.values()
         data = self.make_batch_request(queries)
         return batch.__class__(zip(labels, data))
 

--- a/facebook.py
+++ b/facebook.py
@@ -100,18 +100,9 @@ class AdsAPI(object):
     # New API
     def make_labeled_batch_request(self, batch):
         """Makes a batched request with label against the Facebook Ads API endpoint."""
-        try:
-            labels = batch.keys()
-            queries = batch.values()
-            data = self.make_batch_request(queries)
-            # For debugging
-            self.data = data
-            return dict(zip(labels, data))
-        except urllib2.HTTPError as e:
-            print '%s' % e
-            return json.load(e)
-        except urllib2.URLError as e:
-            print 'URLError: %s' % e.reason
+        labels, queries = batch.items()
+        data = self.make_batch_request(queries)
+        return batch.__class__(zip(labels, data))
 
     def debug_token(self, token):
         """Returns debug information about the given token."""

--- a/facebook.py
+++ b/facebook.py
@@ -1,14 +1,9 @@
-import codecs
 import datetime
 import hashlib
 import hmac
-import io
 import json
 import logging
-import mimetypes
-import sys
 import requests
-import uuid
 
 from urlobject import URLObject as URL
 

--- a/facebook.py
+++ b/facebook.py
@@ -17,57 +17,6 @@ FACEBOOK_API = 'https://graph.facebook.com'
 logger = logging.getLogger(__name__)
 
 
-class MultipartFormdataEncoder(object):
-    def __init__(self):
-        self.boundary = uuid.uuid4().hex
-        self.content_type = 'multipart/form-data; boundary={}'.format(
-            self.boundary)
-
-    @classmethod
-    def u(cls, s):
-        if sys.hexversion < 0x03000000 and isinstance(s, str):
-            s = s.decode('utf-8')
-        if sys.hexversion >= 0x03000000 and isinstance(s, bytes):
-            s = s.decode('utf-8')
-        return s
-
-    def iter(self, fields, files):
-        """
-        fields is a sequence of (name, value) elements for regular form fields.
-        files is a sequence of (name, file-like) elements for data
-        to be uploaded as files.
-        Yield body's chunk as bytes
-        """
-        encoder = codecs.getencoder('utf-8')
-        for key, value in fields.iteritems():
-            key = self.u(key)
-            yield encoder('--{}\r\n'.format(self.boundary))
-            yield encoder(self.u(
-                'Content-Disposition: form-data; name="{}"\r\n').format(key))
-            yield encoder('\r\n')
-            if isinstance(value, int) or isinstance(value, float):
-                value = str(value)
-            yield encoder(self.u(value))
-            yield encoder('\r\n')
-        for key, value in files.iteritems():
-            key = self.u(key)
-            filename = self.u(value.name)
-            yield encoder('--{}\r\n'.format(self.boundary))
-            yield encoder(self.u('Content-Disposition: form-data; name="{}"; filename="{}"\r\n').format(key, filename))
-            yield encoder('Content-Type: {}\r\n'.format(mimetypes.guess_type(filename)[0] or 'application/octet-stream'))
-            yield encoder('\r\n')
-            buff = value.read()
-            yield (buff, len(buff))
-            yield encoder('\r\n')
-        yield encoder('--{}--\r\b'.format(self.boundary))
-
-    def encode(self, fields, files):
-        body = io.BytesIO()
-        for chunk, chunk_len in self.iter(fields, files):
-            body.write(chunk)
-        return self.content_type, body.getvalue()
-
-
 class AdsAPIError(Exception):
     """
     Errors as defined in the Facebook documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.2.1
+URLObject==2.3.4

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,8 @@ setup(
     description='Python client for the Facebook Ads API',
     long_description=open('README.md').read(),
     cmdclass={'test': TestCommand},
+    install_requires=[
+        'requests>=2.2.1',
+        'URLObject>=2.3.4',
+    ],
 )


### PR DESCRIPTION
Using the requests library simplifies the code while adding the benefit of HTTP connection pooling powered by urllib3.  Most Python applications already use the requests library, so it should be fine to add the dependency.

This commit also changes the URL handling to use URLObject rather than manually concatenating with slashes and question marks.  That way there's no chance of doubled slashes, and query strings are merged properly.

Additional notes:
- Error handling and behavior of `AdsAPIError` is preserved.
- `MultipartFormdataEncoder` is no longer needed, since the library handles that.
- `make_labeled_batch_request` is simplified since the error handling is in `make_batch_request` (this is actually true regardless of the rest of this commit).  It will additionally preserve an `OrderedDict` if passed in by the caller.
