### PR TITLE
supporting more targeting specs

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -715,7 +715,7 @@ class AdsAPI(object):
             'bid_info': bid_info,
             'campaign_id': campaign_id,
             'creative': json.dumps({'creative_id': creative_id}),
-            'targeting': json.dumps({"countries": targeting}),
+            'targeting': json.dumps(targeting),
         }
         if conversion_specs:
             args['conversion_specs'] = json.dumps(conversion_specs)

--- a/test_facebook.py
+++ b/test_facebook.py
@@ -221,7 +221,7 @@ class FacebookAdsAPITest(unittest.TestCase):
         self.assertNotIn('error', response)
 
     def test_create_adgroup(self):
-        targeting = {'countries': ['KR']}
+        targeting = {'geo_locations': {'countries': ['KR']}}
         conversion_specs = [{"action.type": ["offsite_conversion"],
                              "offsite_pixel": [OFFSITE_PIXEL_ID]}]
         response = self.api.create_adgroup(


### PR DESCRIPTION
I was not able to create adgroups because Facebook tells me that the format `{"countries": [...]}` is deprecated. We should use `geo_locations` instead.

This change also allows you to set any other fields in the targeting spec (like interests, cities, user_os, etc...).
