### PR TITLE
Show Facebook error in the str representation of the AdsAPIError

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -79,6 +79,9 @@ class AdsAPIError(Exception):
         self.code = data['error']['code']
         self.type = data['error']['type']
 
+    def __str__(self):
+        return '(%s %s) %s' % (self.type, self.code, self.message)
+
 
 class AdsAPI(object):
     """A client for the Facebook Ads API."""


### PR DESCRIPTION
This makes it easier to track errors. The exceptions look like this:

```
AdsAPIError: (Exception 12345678) This is an example of an error message.
```
