### PR TITLE
Fixed how bid_info is sent when creating adgroups

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -712,7 +712,7 @@ class AdsAPI(object):
         args = {
             'name': name,
             'bid_type': bid_type,
-            'bid_info': bid_info,
+            'bid_info': json.dumps(bid_info),
             'campaign_id': campaign_id,
             'creative': json.dumps({'creative_id': creative_id}),
             'targeting': json.dumps(targeting),


### PR DESCRIPTION
Facebook was giving back an error when creating adgroups. The bid_info was not converted to string properly before converting to URL encoding.
