### PR TITLE
remove unused argument from get_custom_audince()

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -433,7 +433,7 @@ class AdsAPI(object):
         path = '%s/conversions' % adgroup_id
         return self.make_request(path, 'GET', batch=batch)
 
-    def get_custom_audiences(self, account_id, audience_id, batch=False):
+    def get_custom_audiences(self, account_id, batch=False):
         """Returns the information for a given audience."""
         path = 'act_%s/customaudiences' % account_id
         return self.make_request(path, 'GET', batch=batch)


### PR DESCRIPTION
remove the audience_id argument from the get_custom_audince() method because the argument is not used
