### PR TITLE
added call to action in link page post

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -76,12 +76,12 @@ class AdsAPIError(Exception):
     def __init__(self, error):
         try:
             self.error = json.load(error)
-        except ValueError:
-            self.error = error
-            self.message = None
+        except:
+            self.message = '{}'.format(error)
             self.code = None
             self.type = None
-            self.str = '{} (invalid JSON)'.format(error)
+            self.str = self.message
+            self.error = {'message': self.message}
         else:
             self.message = self.error.get('error', {}).get('message')
             self.code = self.error.get('error', {}).get('code')
@@ -603,8 +603,11 @@ class AdsAPI(object):
                               thumbnail=None, name=None, caption=None,
                               description=None, published=None, call_to_action=None, batch=False):
         """Creates a link page post on the given page."""
-        # TODO: this method is calling the API twice; combine them into batch
         page_access_token = self.get_page_access_token(page_id)
+        if 'error' in page_access_token:
+            return page_access_token
+        if 'access_token' not in page_access_token:
+            raise AdsAPIError('Could not get page access token. (Do you have manage pages permission?)')
         path = '%s/feed' % page_id
         args = {
             'access_token': page_access_token['access_token'],
@@ -924,4 +927,3 @@ class AdsAPI(object):
             if not next_page:
                 break
             response = json.load(urllib2.urlopen(next_page))
-


### PR DESCRIPTION
The call to action is used in mobile app ads (https://developers.facebook.com/docs/reference/ads-api/mobile-app-ads/#create). In this case the link parameter is not required so I made it optional.

Also I fixed an issue with the exception, because the error in json.load is not always ValueError.
