### PR TITLE
Cleanup deprecated creative type 27 method, made app-id, app-secret optional

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -803,27 +803,7 @@ class AdsAPI(object):
         path = '%s' % campaign_id
         return self.make_request(path, 'DELETE', batch=batch)
 
-    # this method is deprecated
-    def create_adcreative_type_27(self, account_id, object_id,
-                                  auto_update=None, story_id=None,
-                                  url_tags=None, name=None, batch=False):
-        """Creates an ad creative in the given ad account."""
         logger.warn("This method is deprecated and is replaced with get_ads_pixels.")
-        path = 'act_%s/adcreatives' % account_id
-        args = {
-            'type': 27,
-            'object_id': object_id,
-        }
-        if auto_update:
-            args['auto_update'] = auto_update
-        if story_id:
-            args['story_id'] = story_id
-        if url_tags:
-            args['url_tags'] = url_tags
-        if name:
-            args['name'] = name
-        return self.make_request(path, 'POST', args, batch=batch)
-
     def create_adcreative(self, account_id, object_story_id=None, batch=False):
         """Creates an ad creative in the given ad account."""
         path = 'act_%s/adcreatives' % account_id


### PR DESCRIPTION
This is a small version of https://github.com/narrowcast/facebook-ads-api/pull/37

Creatives are no longer created with type numbers, and 27 is no longer a thing, so deleted the method since I believe any code that calls it is broken.

Made the app_id and app_secret optional with default values. It cleans up our code to not have to retain and pass around more secret information than necessary: the access token from Facebook already has already authenticated against the app and app secret, and this library doesn't deal with authentication, so these really should be out of its scope. This change also will not break existing code.
