### PR TITLE
Generators that handle facebook pagination

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -984,7 +984,7 @@ def iterate_by_page(response):
         next_page = response.get('paging', {}).get('next', '')
         if not next_page:
             break
-            response = json.load(urllib2.urlopen(next_page))
+        response = json.load(urllib2.urlopen(next_page))
 
 
 def iterate_by_item(response):
@@ -1009,4 +1009,4 @@ def iterate_by_item(response):
         next_page = response.get('paging', {}).get('next', '')
         if not next_page:
             break
-            response = json.load(urllib2.urlopen(next_page))
+        response = json.load(urllib2.urlopen(next_page))


### PR DESCRIPTION
The Facebook API does not handle spanning multiple pages, though it provides the URLS necessary to do so.

Two generators were provided so that, if given appropriate responses from the Facebook API, will iterate over all necessary pages to potentially return all facebook data.

Notes:
For now these functions are simple and don't change the original data. Ideally, the API would return a class that abstracted away all of this stuff.
get_stats_by_adaccount always returns a by-page iterator, all I've done is move that function out so anyone can use it. Ideally this function would return the raw message body so that users could choose what iterator (if any) to use, but I left it unaltered for backwards compatibility reasons.
