### PR TITLE
Raise exception on URLError

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -146,6 +146,7 @@ class AdsAPI(object):
             raise AdsAPIError(e)
         except urllib2.URLError as e:
             print 'URLError: %s' % e.reason
+            raise
 
     def make_batch_request(self, batch):
         """Makes a batched request against the Facebook Ads API endpoint."""


### PR DESCRIPTION
In a complex project, just printing to stdout is not enough to handle errors.
If a `URLError` occurs we should re-raise the exception so that the caller is aware of errors. Otherwise a `None` would have been returned.
