### PR TITLE
Feature/add users to audience fix

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -943,7 +943,7 @@ class AdsAPI(object):
         """
         path = "%s/users" % custom_audience_id
         args = {
-            'payload': {'schema': str(schema), 'data': json.dumps(tracking_ids)}
+            'payload': json.dumps({'schema': schema, 'data': tracking_ids})
         }
         return self.make_request(path, 'POST', args, batch)
 


### PR DESCRIPTION
Bugfix: move the json conversion outside the dictionary. The previous version would fail if the schema is passed in as a unicode string, since the u"" representation isn't valid json and it is rejected by Facebook.
