### PR TITLE
Breaking change: Currency is optional in reach estimates: treat it so in the code. 

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -536,17 +536,18 @@ class AdsAPI(object):
         path = 'act_%s/ratecard' % account_id
         return self.make_request(path, 'GET', batch=batch)
 
-    def get_reach_estimate(self, account_id, currency, targeting_spec,
+    def get_reach_estimate(self, account_id, targeting_spec, currency=None,
                            creative_action_spec=None,
                            bid_for=None, batch=False):
         """Returns the reach estimate for the given currency and targeting."""
         path = 'act_%s/reachestimate' % account_id
         args = {
-            'currency': currency,
-            'targeting_spec': targeting_spec,
+            'targeting_spec': json.dumps(targeting_spec),
         }
+        if currency is  not None:
+            args['currency'] = json.dumps(currency)
         if creative_action_spec is not None:
-            args['creative_action_spec'] = creative_action_spec
+            args['creative_action_spec'] = json.dumps(creative_action_spec)
         if bid_for is not None:
             args['bid_for'] = bid_for
         return self.make_request(path, 'GET', args, batch=batch)


### PR DESCRIPTION
From Facebook docs: "Note that targeting_spec is required for accessing /{account-id}/reachestimate while currency is an optional field. The returned CPC and CPM values are based on the currency specified." https://developers.facebook.com/docs/reference/ads-api/reachestimate/v2.2

We only need the reach estimate, not the CPC and CPM values, and we don't need a currency according to the API, so we shouldn't have to apply one to this method either.

Since this change is breaking anyway, I made the json encoding convention consistent with the rest of this file: to use json.dumps on the inside, instead of relying on the caller to do it.

Note that Facebook are removing the Action Spec with 2.2, so callers of this method will need to visit this anyway.
